### PR TITLE
reset, reload, utils-common: accept new slot names

### DIFF
--- a/oc-flash-script.sh
+++ b/oc-flash-script.sh
@@ -155,7 +155,7 @@ while read d ; do
       flash_block[$i]=${parse_info[4]}
       flash_interface[$i]=${parse_info[5]}
       flash_secondary[$i]=${parse_info[6]}
-      printf "%-20s %-30s %-29s %-20s %s\n" "card$i:OPENCAPI-${allcards_array[$i]:0:4}" "${line:6:21}" "${f:0:29}" "${f:30:20}" "${f:51}"
+      printf "%-20s %-30s %-29s %-20s %s\n" "card$i:${allcards_array[$i]}" "${line:6:21}" "${f:0:29}" "${f:30:20}" "${f:51}"
     fi
   done < "$package_root/oc-devices"
   i=$[$i+1]
@@ -305,7 +305,7 @@ wait $PID
 RC=$?
 #if [ $RC -eq 0 ]; then
 #  # reset card only if Flashing was good, TBD
-#  printf "Test infomration ${allcards_array[$c]:0:4}"
-#   ./oc-reset.sh -C OPENCAPI-${allcards_array[$c]:0:4}
+#  printf "Test information ${allcards_array[$c]"
+#   ./oc-reset.sh -C ${allcards_array[$c]}
 #fi
 

--- a/oc-list-cards.sh
+++ b/oc-list-cards.sh
@@ -24,7 +24,7 @@ while read d ; do
       flash_block[$i]=${parse_info[4]}
       flash_interface[$i]=${parse_info[5]}
       flash_secondary[$i]=${parse_info[6]}
-      printf "%-20s %-30s %-29s %-20s %s\n" "card$i:OPENCAPI-${allcards_array[$i]:0:4}" "${line:6:21}" "${f:0:29}" "${f:30:20}" "${f:51}"
+      printf "%-20s %-30s %-29s %-20s %s\n" "card$i:${allcards_array[$i]}" "${line:6:21}" "${f:0:29}" "${f:30:20}" "${f:51}"
     fi
   done < "$package_root/oc-devices"
   i=$[$i+1]

--- a/oc-reload.sh
+++ b/oc-reload.sh
@@ -25,11 +25,13 @@ program=`basename "$0"`
 # Print usage message helper function
 function usage() {
   echo "Usage:  sudo ${program} [OPTIONS]"
-  echo "    [-C <card>] card to reset. You need to Specify bdf device number!"
-  echo "      Example: if you want to reset card" 
+  echo "    [-C <card>] card to reload."
+  echo "      Example: if you want to reload card"
   echo -e "        \033[33m IBM,oc-snap.0004:00:00.1.0 \033[0m"
   echo "      Command line should be:"
-  echo -e "        \033[33m sudo ./oc-reset.sh -C OPENCAPI-0004 \033[0m"
+  echo -e "        \033[33m sudo ./oc-reload.sh -C IBM,oc-snap.0004:00:00.1.0 \033[0m"
+  echo "      Or:"
+  echo -e "        \033[33m sudo ./oc-reload.sh -C 0004:00:00.0 \033[0m"
   echo "    [-V] Print program version (${version})"
   echo "    [-h] Print this help message."
   echo
@@ -120,8 +122,6 @@ if [ -n "$card" ]; then
 else
         select_cards
         # Find all OC cards in the system
-	allcards=`ls -d /sys/class/ocxl/IBM* | awk -F"/sys/class/ocxl/" '{ print $2 }' |sed s/IBM,MEMCPY3./OPENCAPI-/g  |sed s/IBM,AFP3./OPENCAPI-/g |sed s/IBM,oc-snap./OPENCAPI-/g | awk -F":" '{print $1}' | sort`
-        allcards_array=($allcards)
         n=`ls -d /sys/class/ocxl/IBM* | awk -F"/sys/class/ocxl/" '{ print $2 }' | wc -w`
 	if (($c < 0 )) || (( "$c" >= "$n" )); then
             printf "${bold}ERROR:${normal} Wrong card number ${c}\n"

--- a/oc-reset.sh
+++ b/oc-reset.sh
@@ -25,11 +25,13 @@ program=`basename "$0"`
 # Print usage message helper function
 function usage() {
   echo "Usage:  sudo ${program} [OPTIONS]"
-  echo "    [-C <card>] card to reset. You need to Specify bdf device number!"
+  echo "    [-C <card>] card to reset."
   echo "      Example: if you want to reset card" 
   echo -e "        \033[33m IBM,oc-snap.0004:00:00.1.0 \033[0m"
   echo "      Command line should be:"
-  echo -e "        \033[33m sudo ./oc-reset.sh -C OPENCAPI-0004 \033[0m"
+  echo -e "        \033[33m sudo ./oc-reset.sh -C IBM,oc-snap.0004:00:00.1.0 \033[0m"
+  echo "      Or:"
+  echo -e "        \033[33m sudo ./oc-reset.sh -C 0004:00:00.0 \033[0m"
   echo "    [-V] Print program version (${version})"
   echo "    [-h] Print this help message."
   echo
@@ -121,8 +123,6 @@ if [ -n "$card" ]; then
 else
         select_cards
         # Find all OC cards in the system
-	allcards=`ls -d /sys/class/ocxl/IBM* | awk -F"/sys/class/ocxl/" '{ print $2 }' |sed s/IBM,MEMCPY3./OPENCAPI-/g  |sed s/IBM,AFP3./OPENCAPI-/g |sed s/IBM,oc-snap./OPENCAPI-/g | awk -F":" '{print $1}' | sort`
-        allcards_array=($allcards)
         n=`ls -d /sys/class/ocxl/IBM* | awk -F"/sys/class/ocxl/" '{ print $2 }' | wc -w`
 	if (($c < 0 )) || (( "$c" >= "$n" )); then
             printf "${bold}ERROR:${normal} Wrong card number ${c}\n"


### PR DESCRIPTION
This commit extends oc-reset and oc-reload to accept the new
opencapi slot names, that are platform-dependant.

Platforms that still use the previous OPENCAPI-xxxx standard
for slot names are supported as well.

Signed-off-by: Philippe Bergheaud <felix@linux.ibm.com>