### PR TITLE
oc-reload.sh: Added OPTIND=1 in order to have getopts working properly

### DIFF
--- a/oc-reload.sh
+++ b/oc-reload.sh
@@ -81,6 +81,9 @@ function select_cards() {
 
 }
 
+# OPTIND Reset done in order to use getopts even if not the first time getopts is called (when sourcing this script by oc-flash-script.sh for example)
+OPTIND=1
+
 # Parse any options given on the command line
 while getopts ":C:Vh" opt; do
   case ${opt} in


### PR DESCRIPTION
oc-reload.sh is "sourced" by oc-flash-script.sh which is also using getopts, so we need to reset OPTIND variable in oc-reload.sh
(oc-reload.sh was not working at all when sourced by oc-flash-script.sh)

Signed-off-by: fmoyen <fabrice_moyen@fr.ibm.com>