### PR TITLE
Some checks for prettier output

### DIFF
--- a/oc-list-cards.sh
+++ b/oc-list-cards.sh
@@ -7,28 +7,36 @@ lspci >/dev/null 2>&1
 [ -h $0 ] && package_root=`ls -l "$0" |sed -e 's|.*-> ||'` || package_root="$0"
 package_root=$(dirname $package_root)
 
-# print table header
-printf "${bold}%-21s %-29s %-29s %-20s %s${normal}\n" "#" "Card" "Flashed" "by" "Last Image"
-# Find all OC cards in the system
+# find all OC cards in the system
 allcards=`ls /dev/ocxl 2>/dev/null | awk -F"." '{ print $2 }' | sed s/$/.0/ | sort`
 allcards_array=($allcards)
 
-# print card information and flash history
-i=0;
-while read d ; do
-  p[$i]=$(cat /sys/bus/pci/devices/${allcards_array[$i]}/subsystem_device)
-  f=$(cat /var/ocxl/card$i)
-  while IFS='' read -r line || [[ -n $line ]]; do
-    if [[ ${line:0:6} == ${p[$i]:0:6} ]]; then
-      parse_info=($line)
-      board_vendor[$i]=${parse_info[1]}
-      fpga_type[$i]=${parse_info[2]}
-      flash_partition[$i]=${parse_info[3]}
-      flash_block[$i]=${parse_info[4]}
-      flash_interface[$i]=${parse_info[5]}
-      flash_secondary[$i]=${parse_info[6]}
-      printf "%-20s %-30s %-29s %-20s %s\n" "card$i:${allcards_array[$i]}" "${line:6:21}" "${f:0:29}" "${f:30:20}" "${f:51}"
-    fi
-  done < "$package_root/oc-devices"
-  i=$[$i+1]
-done < <( lspci -d "1014":"062b" -s .1 )
+# only execute if devices were found
+if [ ${#allcards_array[@]} -ne 0 ]; then
+   # print table header
+   printf "${bold}%-21s %-29s %-29s %-20s %s${normal}\n" "#" "Card" "Flashed" "by" "Last Image"
+
+   # print card information and flash history
+   i=0
+   while read d ; do
+      p[$i]=$(cat /sys/bus/pci/devices/${allcards_array[$i]}/subsystem_device)
+      # prevent error message if there are no information for the card
+      [ -f /var/ocxl/card$i ] && f=$(cat /var/ocxl/card$i)
+
+      while IFS='' read -r line || [[ -n $line ]]; do
+         if [[ ${line:0:6} == ${p[$i]:0:6} ]]; then
+            parse_info=($line)
+            board_vendor[$i]=${parse_info[1]}
+            fpga_type[$i]=${parse_info[2]}
+            flash_partition[$i]=${parse_info[3]}
+            flash_block[$i]=${parse_info[4]}
+            flash_interface[$i]=${parse_info[5]}
+            flash_secondary[$i]=${parse_info[6]}
+            printf "%-20s %-30s %-29s %-20s %s\n" "card$i:${allcards_array[$i]}" "${line:6:21}" "${f:0:29}" "${f:30:20}" "${f:51}"
+         fi
+      done < "$package_root/oc-devices"
+      i=$[$i+1]
+   done < <( lspci -d "1014":"062b" -s .1 )
+else
+   printf "No OpenCAPI cards found!\n"
+fi


### PR DESCRIPTION
1. If there are no cards then only this information will be printed. 
Before:  `#                     Card                          Flashed                       by                   Last Image`
Now:  `No OpenCAPI cards found!`

2. If there are cards but maybe no image information instead of error message empty fields are displayed
Before:
`#                     Card                          Flashed                       by                   Last Image`
`cat: /var/ocxl/card0: No such file or directory`
`card0:0004:00:00.0    OC-AD9H7(VU37P)`
Now:
`#                     Card                          Flashed                       by                   Last Image`
`card0:0004:00:00.0    OC-AD9H7(VU37P)`

